### PR TITLE
Updates to latest analyzer version

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,6 +11,6 @@ dependencies:
   equatable: ^2.0.5
 
 dev_dependencies:
-  custom_lint: ^0.6.0
+  custom_lint: ^0.7.5
   equatable_lint_ultimate:
     path: ../

--- a/lib/src/lints/always_call_super_props_when_overriding_equatable_props/always_call_super_props_when_overriding_equatable_props.dart
+++ b/lib/src/lints/always_call_super_props_when_overriding_equatable_props/always_call_super_props_when_overriding_equatable_props.dart
@@ -28,7 +28,7 @@ class AlwaysCallSuperPropsWhenOverridingEquatableProps extends DartLintRule {
       required equatablePropsClassMember,
       required equatablePropsExpressionDetails,
     }) {
-      reporter.reportErrorForNode(_code, equatablePropsClassMember);
+      reporter.atNode(equatablePropsClassMember, _code);
     });
   }
 

--- a/lib/src/lints/missing_field_in_equatable_props/missing_field_in_equatable_props.dart
+++ b/lib/src/lints/missing_field_in_equatable_props/missing_field_in_equatable_props.dart
@@ -40,7 +40,7 @@ class MissingFieldInEquatableProps extends DartLintRule {
               false;
 
       if (!isFieldInEquatableProps) {
-        reporter.reportErrorForNode(_code, fieldNode);
+        reporter.atNode(fieldNode, _code);
       }
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  analyzer: "^6.4.1"
-  analyzer_plugin: ^0.11.0
+  analyzer: "^7.4.5"
+  analyzer_plugin: ^0.13.0
   collection: ^1.18.0
-  custom_lint_builder: ">=0.2.12 <0.7.0"
+  custom_lint_builder: ">=0.2.12 <0.8.0"
   equatable: ^2.0.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  analyzer: "^7.4.5"
-  analyzer_plugin: ^0.13.0
+  analyzer: ^7.4.5
+  analyzer_plugin: ^0.13.1  
   collection: ^1.18.0
   custom_lint_builder: ">=0.2.12 <0.8.0"
   equatable: ^2.0.5


### PR DESCRIPTION
## Description
Updates the package to use the latest analyzer and custom_lint version. Marked as a draft as there seem to custom_lint fails to build with `analyzer_plugin: ^0.13.0` after they renamed `.publiclyExporting2` to `.publiclyExporting`. Will follow up on this pull request as soon as they resolve the issue and release a new, compatible version of `analyzer_plugin`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
